### PR TITLE
Correct shebang to avoid confusion

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 chain_exists() {
     [ $# -lt 1 -o $# -gt 2 ] && {


### PR DESCRIPTION
In this case the shebang isn't even used as the script is invoked with /bin/sh &syscommand(**LINE**,"/bin/sh /etc/csf/csfpost.sh"); (even with the csf-pre_post_sh project as it just sources the script).
